### PR TITLE
Rename resources to calico-cni*, rename build script

### DIFF
--- a/build-resources.sh
+++ b/build-resources.sh
@@ -60,7 +60,7 @@ for arch in ${arches}; do
   echo "calico cni-plugin $calico_cni_version" > BUILD_INFO
 
   chmod +x calico calico-ipam
-  tar -zcvf ../calico-$arch.tar.gz .
+  tar -zcvf ../calico-cni-$arch.tar.gz .
 
   popd
   rm -rf resource-build-$arch

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -25,11 +25,11 @@ requires:
   kube-api-endpoint:
     interface: http
 resources:
-  calico:
+  calico-cni:
     type: file
-    filename: calico.tar.gz
-    description: 'Calico resource tarball for amd64'
-  calico-arm64:
+    filename: calico-cni.tar.gz
+    description: 'calico-cni resource tarball for amd64'
+  calico-cni-arm64:
     type: file
-    filename: calico.tar.gz
-    description: 'Calico resource tarball for arm64'
+    filename: calico-cni.tar.gz
+    description: 'Calico-cni resource tarball for arm64'

--- a/reactive/calico.py
+++ b/reactive/calico.py
@@ -44,9 +44,9 @@ def install_calico_binaries():
     # on intel, the resource is called 'calico'; other arches have a suffix
     architecture = arch()
     if architecture == "amd64":
-        resource_name = 'calico'
+        resource_name = 'calico-cni'
     else:
-        resource_name = 'calico-{}'.format(architecture)
+        resource_name = 'calico-cni-{}'.format(architecture)
 
     try:
         archive = resource_get(resource_name)


### PR DESCRIPTION
The resources only contain Calico CNI now. I really wanted to rename them before we get too entrenched in CI and official releases.