### PR TITLE
Fix charm stuck trying to create IPPool

### DIFF
--- a/reactive/calico.py
+++ b/reactive/calico.py
@@ -304,8 +304,7 @@ def deploy_network_policy_controller():
         f.write(license_key)
     try:
         calicoctl('apply', '-f', license_key_path)
-    except CalledProcessError as e:
-        log(e.output)
+    except CalledProcessError:
         msg = 'Waiting to retry applying license-key'
         log(msg)
         status_set('waiting', msg)
@@ -397,7 +396,11 @@ def calicoctl(*args):
         image
     ]
     cmd += list(args)
-    return check_output(cmd)
+    try:
+        return check_output(cmd)
+    except CalledProcessError as e:
+        log(e.output)
+        raise
 
 
 def arch():

--- a/templates/calico-node.service
+++ b/templates/calico-node.service
@@ -15,7 +15,7 @@ ExecStart=/usr/bin/docker run --net=host --privileged --name=calico-node \
   -e ETCD_KEY_FILE={{ etcd_key_path }} \
   -e NODENAME={{ nodename }} \
   -e IP={{ ip }} \
-  -e NO_DEFAULT_POOLS= \
+  -e NO_DEFAULT_POOLS=true \
   -e AS= \
   -e CALICO_LIBNETWORK_ENABLED=true \
   -e IP6= \


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charm-tigera-secure-ee/+bug/1818160

This prevents cnx-node from creating a default pool that conflicts with the pool created by the charm.