### PR TITLE
Detect and handle changes in etcd info

### DIFF
--- a/reactive/calico.py
+++ b/reactive/calico.py
@@ -12,6 +12,7 @@ from charms.reactive import (when, when_not, when_any, is_state, set_state,
                              remove_state)
 from charms.reactive import hook
 from charms.reactive import endpoint_from_flag
+from charms.reactive import data_changed
 from charmhelpers.core import hookenv, unitdata
 from charmhelpers.core.hookenv import log, status_set, resource_get
 from charmhelpers.core.hookenv import DEBUG, ERROR
@@ -119,7 +120,18 @@ def blocked_without_etcd():
 def install_etcd_credentials():
     etcd = endpoint_from_flag('etcd.available')
     etcd.save_client_credentials(ETCD_KEY_PATH, ETCD_CERT_PATH, ETCD_CA_PATH)
+    # record initial data so that we can detect changes
+    data_changed('calico.etcd.data', (etcd.get_connection_string(),
+                                      etcd.get_client_credentials()))
     set_state('calico.etcd-credentials.installed')
+
+
+@when('etcd.tls.available', 'calico.service.installed')
+def check_etcd_updates():
+    etcd = endpoint_from_flag('etcd.available')
+    if data_changed('calico.etcd.data', (etcd.get_connection_string(),
+                                         etcd.get_client_credentials())):
+        remove_state('calico.service.installed')
 
 
 def get_bind_address():

--- a/reactive/calico.py
+++ b/reactive/calico.py
@@ -131,6 +131,9 @@ def check_etcd_updates():
     etcd = endpoint_from_flag('etcd.available')
     if data_changed('calico.etcd.data', (etcd.get_connection_string(),
                                          etcd.get_client_credentials())):
+        etcd.save_client_credentials(ETCD_KEY_PATH,
+                                     ETCD_CERT_PATH,
+                                     ETCD_CA_PATH)
         remove_state('calico.service.installed')
 
 

--- a/reactive/calico.py
+++ b/reactive/calico.py
@@ -135,6 +135,7 @@ def check_etcd_updates():
                                      ETCD_CERT_PATH,
                                      ETCD_CA_PATH)
         remove_state('calico.service.installed')
+        remove_state('calico.npc.deployed')
 
 
 def get_bind_address():

--- a/templates/calico-kube-controllers.yaml
+++ b/templates/calico-kube-controllers.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: calico-kube-controllers
+    cdk-restart-on-ca-change: "true"
   annotations:
     scheduler.alpha.kubernetes.io/critical-pod: ''
 spec:
@@ -20,6 +21,10 @@ spec:
       namespace: kube-system
       labels:
         k8s-app: calico-kube-controllers
+      annotations:
+        # annotate etcd cert hash, so when the cert changes, k8s will restart
+        # the pods in this deployment
+        cdk-etcd-cert-hash: "{{ etcd_cert_hash }}"
     spec:
       nodeSelector:
         beta.kubernetes.io/os: linux

--- a/templates/cnx-etcd.yaml
+++ b/templates/cnx-etcd.yaml
@@ -263,6 +263,7 @@ metadata:
   labels:
     apiserver: "true"
     k8s-app: cnx-apiserver
+    cdk-restart-on-ca-change: "true"
 spec:
   replicas: 1
   strategy:
@@ -277,6 +278,10 @@ spec:
       labels:
         apiserver: "true"
         k8s-app: cnx-apiserver
+      annotations:
+        # annotate etcd cert hash, so when the cert changes, k8s will restart
+        # the pods in this deployment
+        cdk-etcd-cert-hash: "{{ etcd_cert_hash }}"
     spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
@@ -423,6 +428,7 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: cnx-manager
+    cdk-restart-on-ca-change: "true"
 spec:
   replicas: 1
   strategy:

--- a/templates/elasticsearch-operator.yaml
+++ b/templates/elasticsearch-operator.yaml
@@ -93,6 +93,7 @@ metadata:
   namespace: calico-monitoring
   labels:
     operator: prometheus
+    cdk-restart-on-ca-change: "true"
 spec:
   replicas: 1
   template:
@@ -185,6 +186,8 @@ kind: Deployment
 metadata:
   name: elasticsearch-operator
   namespace: calico-monitoring
+  labels:
+    cdk-restart-on-ca-change: "true"
 spec:
   replicas: 1
   template:

--- a/templates/monitor-calico.yaml
+++ b/templates/monitor-calico.yaml
@@ -403,6 +403,7 @@ metadata:
   namespace: calico-monitoring
   labels:
     k8s-app: tigera-fluentd-node
+    cdk-restart-on-ca-change: "true"
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
The connection and cert info for etcd can change and needs to trigger the service config being updated and the service restarted.