### PR TITLE
Add support for series upgrade

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.5, 3.6, 3.7]
+        python: [3.5, 3.6, 3.7, 3.8]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -1,0 +1,22 @@
+name: Run tests with Tox
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: [3.5, 3.6, 3.7]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install Tox and any other packages
+        run: pip install tox
+      - name: Run Tox
+        run: tox -e py  # Run tox using the version of Python in `PATH`

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.tox/
+__pycache__/
+*.pyc

--- a/layer.yaml
+++ b/layer.yaml
@@ -3,4 +3,5 @@ includes:
   - 'interface:kubernetes-cni'
   - 'interface:http'
   - 'layer:basic'
+  - 'layer:status'
 repo: https://github.com/juju-solutions/layer-tigera-secure-ee.git

--- a/reactive/calico.py
+++ b/reactive/calico.py
@@ -270,7 +270,7 @@ def deploy_network_policy_controller():
     if not os.path.exists(key_path) or not os.path.exists(cert_path):
         msg = 'Waiting for cert generation'
         log(msg)
-        hookenv.status.waiting(msg)
+        status.waiting(msg)
         return
 
     etcd = endpoint_from_flag('etcd.available')

--- a/reactive/calico.py
+++ b/reactive/calico.py
@@ -15,12 +15,13 @@ from charms.reactive import hook
 from charms.reactive import endpoint_from_flag
 from charms.reactive import data_changed
 from charmhelpers.core import hookenv, unitdata
-from charmhelpers.core.hookenv import log, status_set, resource_get
+from charmhelpers.core.hookenv import log, resource_get
 from charmhelpers.core.hookenv import DEBUG, ERROR
 from charmhelpers.core.hookenv import unit_private_ip
 from charmhelpers.core.templating import render
 from charmhelpers.core.host import (arch, service, service_restart,
                                     service_running)
+from charms.layer import status
 
 # TODO:
 #   - Handle the 'stop' hook by stopping and uninstalling all the things.
@@ -60,7 +61,7 @@ def upgrade_charm():
 
 @hook('pre-series-upgrade')
 def pre_series_upgrade():
-    status_set('blocked', 'Series upgrade in progress')
+    status.blocked('Series upgrade in progress')
 
 
 @when_not('calico.binaries.installed')
@@ -78,23 +79,23 @@ def install_calico_binaries():
     except Exception:
         message = 'Error fetching the calico resource.'
         log(message)
-        status_set('blocked', message)
+        status.blocked(message)
         return
 
     if not archive:
         message = 'Missing calico resource.'
         log(message)
-        status_set('blocked', message)
+        status.blocked(message)
         return
 
     filesize = os.stat(archive).st_size
     if filesize < 1000000:
         message = 'Incomplete calico resource'
         log(message)
-        status_set('blocked', message)
+        status.blocked(message)
         return
 
-    status_set('maintenance', 'Unpacking calico resource.')
+    status.maintenance('Unpacking calico resource.')
 
     charm_dir = os.getenv('CHARM_DIR')
     unpack_path = os.path.join(charm_dir, 'files', 'calico')
@@ -120,7 +121,7 @@ def install_calico_binaries():
 @when('calico.binaries.installed')
 @when_not('etcd.connected')
 def blocked_without_etcd():
-    status_set('blocked', 'Waiting for relation to etcd')
+    status.blocked('Waiting for relation to etcd')
 
 
 @when('etcd.tls.available')
@@ -174,7 +175,7 @@ def get_bind_address():
 @when_not('calico.service.installed')
 def install_calico_service():
     ''' Install the calico-node systemd service. '''
-    status_set('maintenance', 'Installing calico-node service.')
+    status.maintenance('Installing calico-node service.')
     etcd = endpoint_from_flag('etcd.available')
     service_path = os.path.join(os.sep, 'lib', 'systemd', 'system',
                                 'calico-node.service')
@@ -203,7 +204,7 @@ def install_calico_service():
 @when_not('calico.pool.configured')
 def configure_calico_pool():
     ''' Configure Calico IP pool. '''
-    status_set('maintenance', 'Configuring Calico IP pool')
+    status.maintenance('Configuring Calico IP pool')
     config = hookenv.config()
     context = {
         'cidr': CALICO_CIDR,
@@ -214,7 +215,7 @@ def configure_calico_pool():
     try:
         calicoctl('apply', '-f', '/tmp/calico-pool.yaml')
     except CalledProcessError:
-        status_set('waiting', 'Waiting to retry calico pool configuration')
+        status.waiting('Waiting to retry calico pool configuration')
         return
     set_state('calico.pool.configured')
 
@@ -229,7 +230,7 @@ def reconfigure_calico_pool():
 @when_not('calico.cni.configured')
 def configure_cni():
     ''' Configure Calico CNI. '''
-    status_set('maintenance', 'Configuring Calico CNI')
+    status.maintenance('Configuring Calico CNI')
     cni = endpoint_from_flag('cni.is-worker')
     etcd = endpoint_from_flag('etcd.available')
     os.makedirs('/etc/cni/net.d', exist_ok=True)
@@ -249,7 +250,7 @@ def configure_cni():
 @when('etcd.available', 'cni.is-master')
 @when_not('calico.cni.configured')
 def configure_master_cni():
-    status_set('maintenance', 'Configuring Calico CNI')
+    status.maintenance('Configuring Calico CNI')
     cni = endpoint_from_flag('cni.is-master')
     cni.set_config(cidr=CALICO_CIDR, cni_conf_file='10-calico.conflist')
     set_state('calico.cni.configured')
@@ -260,7 +261,7 @@ def configure_master_cni():
 @when_not('calico.npc.deployed')
 def deploy_network_policy_controller():
     ''' Deploy the Calico network policy controller. '''
-    status_set('maintenance', 'Applying registry credentials secret')
+    status.maintenance('Applying registry credentials secret')
 
     # FIXME: We're just stealing a server key and cert from a random
     # worker. What should really go here?
@@ -269,7 +270,7 @@ def deploy_network_policy_controller():
     if not os.path.exists(key_path) or not os.path.exists(cert_path):
         msg = 'Waiting for cert generation'
         log(msg)
-        hookenv.status_set('waiting', msg)
+        hookenv.status.waiting(msg)
         return
 
     etcd = endpoint_from_flag('etcd.available')
@@ -323,7 +324,7 @@ def deploy_network_policy_controller():
         ]
 
     for template, context in templates:
-        status_set('maintenance', 'Applying ' + template)
+        status.maintenance('Applying ' + template)
         dest = '/tmp/' + template
         render(template, dest, context)
         try:
@@ -331,7 +332,7 @@ def deploy_network_policy_controller():
         except CalledProcessError:
             msg = 'Waiting to retry applying ' + template
             log(msg)
-            status_set('waiting', msg)
+            status.waiting(msg)
             return
 
     license_key_b64 = hookenv.config('license-key')
@@ -344,7 +345,7 @@ def deploy_network_policy_controller():
     except CalledProcessError:
         msg = 'Waiting to retry applying license-key'
         log(msg)
-        status_set('waiting', msg)
+        status.waiting(msg)
         return
 
     db.set('tigera.apiserver_ips_used', apiserver_ips)
@@ -357,9 +358,9 @@ def deploy_network_policy_controller():
 @when_not('upgrade.series.in-progress')
 def ready():
     if not service_running('calico-node'):
-        status_set('waiting', 'Waiting for service: calico-node')
+        status.waiting('Waiting for service: calico-node')
     else:
-        status_set('active', 'Calico is active')
+        status.active('Calico is active')
 
 
 @when('config.changed.registry-credentials')
@@ -370,7 +371,7 @@ def registry_credentials_changed():
 @when('calico.ctl.ready')
 @when_not('calico.image.pulled')
 def pull_calicoctl_image():
-    status_set('maintenance', 'Pulling calicoctl image')
+    status.maintenance('Pulling calicoctl image')
     registry = hookenv.config('registry') or DEFAULT_REGISTRY
     encoded_creds = hookenv.config('registry-credentials')
     creds = b64decode(encoded_creds).decode('utf-8')
@@ -385,7 +386,7 @@ def pull_calicoctl_image():
 
     for name, path in images.items():
         if not path or os.path.getsize(path) == 0:
-            status_set('maintenance', 'Pulling {} image'.format(name))
+            status.maintenance('Pulling {} image'.format(name))
 
             if not creds or not creds.get('auths') or \
                     registry not in creds.get('auths'):
@@ -401,7 +402,7 @@ def pull_calicoctl_image():
                     password=password
                 )
         else:
-            status_set('maintenance', 'Loading {} image'.format(name))
+            status.maintenance('Loading {} image'.format(name))
             unzipped = '/tmp/calico-node-image.tar'
             with gzip.open(path, 'rb') as f_in:
                 with open(unzipped, 'wb') as f_out:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import charms.unit_test
+
+
+charms.unit_test.patch_reactive()
+charms.unit_test.patch_module('conctl')

--- a/tests/test_tigera.py
+++ b/tests/test_tigera.py
@@ -1,0 +1,9 @@
+from charmhelpers.core.hookenv import status_set  # patched
+
+from reactive.calico import pre_series_upgrade
+
+
+def test_series_upgrade():
+    assert status_set.call_count == 0
+    pre_series_upgrade()
+    assert status_set.call_count == 1

--- a/tests/test_tigera.py
+++ b/tests/test_tigera.py
@@ -1,9 +1,9 @@
-from charmhelpers.core.hookenv import status_set  # patched
+from charms.layer import status  # patched
 
 from reactive.calico import pre_series_upgrade
 
 
 def test_series_upgrade():
-    assert status_set.call_count == 0
+    assert status.blocked.call_count == 0
     pre_series_upgrade()
-    assert status_set.call_count == 1
+    assert status.blocked.call_count == 1

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,23 @@
+[tox]
+skipsdist = True
+envlist = lint,py3
+
+[tox:travis]
+3.5: lint,py3
+3.6: lint,py3
+3.7: lint,py3
+
+[testenv]
+basepython = python3
+setenv =
+    PYTHONPATH={toxinidir}:{toxinidir}/lib
+deps =
+    pytest
+    flake8
+    ipdb
+    git+https://github.com/juju-solutions/charms.unit_test/#egg=charms.unit_test
+commands = pytest --tb native -s {posargs}
+
+[testenv:lint]
+envdir = {toxworkdir}/py3
+commands = flake8 {toxinidir}/lib {toxinidir}/reactive {toxinidir}/tests


### PR DESCRIPTION
We can't actually pause the service because the series upgrade hooks run on the subordinates before the principal so doing so could interfere with the pod drain process. So instead, we just set a status to let the Juju admin know that it's ok to proceed.

Part of https://bugs.launchpad.net/charm-tigera-secure-ee/+bug/1869944