### PR TITLE
Fix calico-node service failure on xenial due to ASCII locale

### DIFF
--- a/reactive/calico.py
+++ b/reactive/calico.py
@@ -194,6 +194,8 @@ def install_calico_service():
         'ip': get_bind_address(),
         'cnx_node_image': uri,
         'ignore_loose_rpf': hookenv.config('ignore-loose-rpf'),
+        'lc_all': os.environ.get('LC_ALL', 'C.UTF-8'),
+        'lang': os.environ.get('LANG', 'C.UTF-8')
     })
     service_restart('calico-node')
     service('enable', 'calico-node')

--- a/templates/calico-node.service
+++ b/templates/calico-node.service
@@ -4,6 +4,10 @@ Description=calico node
 [Service]
 User=root
 Environment=ETCD_ENDPOINTS={{ connection_string }}
+# Setting LC_ALL and LANG works around a bug that only occurs on Xenial
+# https://bugs.launchpad.net/bugs/1911220
+Environment=LC_ALL={{ lc_all }}
+Environment=LANG={{ lang }}
 PermissionsStartOnly=true
 ExecStartPre=-/usr/local/sbin/charm-env --charm tigera-secure-ee conctl delete calico-node
 ExecStart=/usr/local/sbin/charm-env --charm tigera-secure-ee conctl run \


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/bugs/1911220 for Tigera Secure EE