### PR TITLE
Handle dropped kubeconfig_path from kubernetes-cni interface

### DIFF
--- a/reactive/calico.py
+++ b/reactive/calico.py
@@ -248,7 +248,8 @@ def configure_cni():
         'etcd_key_path': ETCD_KEY_PATH,
         'etcd_cert_path': ETCD_CERT_PATH,
         'etcd_ca_path': ETCD_CA_PATH,
-        'kubeconfig_path': cni_config['kubeconfig_path']
+        'kubeconfig_path': cni_config.get('kubeconfig_path',
+                                          '/root/cdk/kubeconfig')
     }
     render('10-calico.conflist', '/etc/cni/net.d/10-calico.conflist', context)
     cni.set_config(cidr=CALICO_CIDR, cni_conf_file='10-calico.conflist')


### PR DESCRIPTION
The `kubernetes-cni` interface is being changed to no longer include the `kubeconfig_path` value. Ideally, this would create a specific user for Tigera EE, but due to the inability to properly test changes to this, a minimal hard-coded replacement is used instead.

Part of [lp:1920034](https://bugs.launchpad.net/charm-calico/+bug/1920034)